### PR TITLE
Add Lighthouse based metrics, FCI and TTI

### DIFF
--- a/SpeedTracker.gs
+++ b/SpeedTracker.gs
@@ -52,7 +52,8 @@ var WPT_PARAMS = {
   'video': 1,                       // need to capture video to calculate SpeedIndex
   'location': 'Dulles:Chrome.3G',
   'mobile': 1,
-  'fvonly': 1                       // we only need the first view
+  'fvonly': 1,                      // we only need the first view
+  'lighthouse': 1
 };
 
 // Map for metrics from Webpagetest.  Each object contains:
@@ -66,7 +67,9 @@ var DATA_POINTS = [
   {wptName: 'fullyLoaded', prettyName: 'time to full page load', units: 'milliseconds'},
   {wptName: 'image_total', prettyName: 'image bytes', units: 'bytes'},
   {wptName: 'image_savings', prettyName: 'bytes that could be saved through image compression', units: 'bytes'},
-  {wptName: 'gzip_savings', prettyName: 'bytes that could be saved through gzip', units: 'bytes'}
+  {wptName: 'gzip_savings', prettyName: 'bytes that could be saved through gzip', units: 'bytes'},
+  {wptName: 'lighthouse.Performance.first-contentful-paint', prettyName: 'First Contentful Paint marks the time at which the first text or image is painted', units: 'milliseconds'}
+  {wptName: 'lighthouse.Performance.interactive', prettyName: 'Time to interactive is the amount of time it takes for the page to become fully interactive', units: 'milliseconds'}
 ];
 
 


### PR DESCRIPTION
Hi, thank you for making this awesome script and [intro](https://medium.com/dev-channel/introducing-speed-demon-a36d95dd0174)!

Is it possible to add other metrics to speed-demon? Recently I'm planning to use speed-demon to monitor performance metrics and keep performance budgets not to exceed thresholds. FCP and TTI, those kinds of Milestone based metrics are really important for the concept performance budget. And fortunately webpagetest supports lighthouse testing as well, so it would be useful if speed-demon supports it.

This change means speed-demon need to update the spreadsheet as well. Perhaps other people want to have other metrics such as Lighthouse PWA score, not FCI or TTI.  I think that's worth considering.